### PR TITLE
wishbone: Convert to the wishbone_soc interfacing, for better interoperability

### DIFF
--- a/minerva/units/debug/controller.py
+++ b/minerva/units/debug/controller.py
@@ -3,7 +3,6 @@ from amaranth.lib.coding import PriorityEncoder
 
 from ...csr import *
 from ...isa import *
-from ...wishbone import wishbone_layout
 from .dmi import DebugReg, Command, Error, Version, cmd_access_reg_layout
 
 

--- a/minerva/units/debug/top.py
+++ b/minerva/units/debug/top.py
@@ -1,10 +1,10 @@
 from amaranth import *
 from amaranth.hdl.rec import *
+from amaranth_soc import wishbone
 
 
 from ...csr import *
 from ...isa import *
-from ...wishbone import wishbone_layout
 from .controller import *
 from .jtag import *
 from .regfile import *
@@ -24,7 +24,7 @@ jtag_regs = {
 class DebugUnit(Elaboratable, AutoCSR):
     def __init__(self):
         self.jtag = Record(jtag_layout)
-        self.dbus = Record(wishbone_layout)
+        self.dbus = wishbone.Interface(addr_width=30, data_width=32, granularity=8, features={"cti", "bte", "err"}, name="debug_dbus")
 
         self.trigger_haltreq = Signal()
 

--- a/minerva/units/debug/wbmaster.py
+++ b/minerva/units/debug/wbmaster.py
@@ -4,7 +4,6 @@ from operator import or_
 from amaranth import *
 from amaranth.hdl.rec import *
 
-from ...wishbone import wishbone_layout
 from .dmi import *
 
 

--- a/minerva/units/rvficon.py
+++ b/minerva/units/rvficon.py
@@ -5,7 +5,6 @@ from amaranth import *
 from amaranth.hdl.rec import *
 
 from ..isa import *
-from ..wishbone import *
 
 
 __all__ = ["rvfi_layout", "RVFIController"]


### PR DESCRIPTION
The main difference is that the wishbone-soc Arbiter is round-robin, while minerva's current is priority.  Not sure if it matters.  If it does, I'll try to enhance w-soc's.