### PR TITLE
pyproject: migrate to pdm-build

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,3 +1,6 @@
+[tool.pdm.version]
+source = "scm"
+
 [project]
 dynamic = ["version"]
 
@@ -20,11 +23,8 @@ debug = ["jtagtap"]
 "Bug Tracker" = "https://github.com/minerva-cpu/minerva/issues"
 
 [build-system]
-requires = ["wheel", "setuptools>=67.0", "setuptools_scm[toml]>=6.2"]
-build-backend = "setuptools.build_meta"
-
-[tool.setuptools_scm]
-local_scheme = "node-and-timestamp"
+requires = ["pdm-backend"]
+build-backend = "pdm.backend"
 
 [tool.pdm.scripts]
 _.env_file = ".env.toolchain"


### PR DESCRIPTION
This makes the build process a bit nicer, since both the build system and the package manager are the same. Amaranth cannot use this at the moment since it needs to customize `project.urls`.

There's an issue I've encountered in Amaranth with the version number being wrong, not sure if Minerva would have it too. https://github.com/amaranth-lang/amaranth/pull/906